### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/fgimenez/snappy-cloud-image.png?label=ready&title=Ready)](https://waffle.io/fgimenez/snappy-cloud-image)
 [![Build Status](https://travis-ci.org/fgimenez/snappy-cloud-image.svg)](https://travis-ci.org/fgimenez/snappy-cloud-image)
 
 Issues can be tracked on the [Waffle board](https://waffle.io/fgimenez/snappy-cloud-image)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/fgimenez/snappy-cloud-image

This was requested by a real person (user fgimenez) on waffle.io, we're not trying to spam you.
