### PR TITLE
Signal runner error to the caller

### DIFF
--- a/cmd/snappy-cloud-image/main.go
+++ b/cmd/snappy-cloud-image/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	runner := runner.NewRunner(imgDataOrigin, imgDataTarget, imgDriver)
 	if err := runner.Exec(parsedFlags); err != nil {
-		log.Error(err.Error())
+		log.Fatal(err.Error())
 	}
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -49,7 +49,7 @@ type ErrVersion struct {
 }
 
 func (e *ErrVersion) Error() string {
-	return fmt.Sprintf("error SI version %d is lower than cloud version %d", e.siVersion, e.cloudVersion)
+	return fmt.Sprintf("error SI version %d is not greater than cloud version %d", e.siVersion, e.cloudVersion)
 }
 
 // ErrActionUnknown is the type of the error returned by Exec when the


### PR DESCRIPTION
Using log.Fatal implies a call to os.Exit(1), as long as we don't have any defered function to honour this is enough for letting know the caller that something failed.

Also fixed ErrVersion message.
