### PR TITLE
Added cleanup action

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -39,10 +39,17 @@ type Pollster interface {
 	GetLatestVersion(release, channel, arch string) (ver int, err error)
 }
 
-// PollsterCreator is a Pollster that can also create new images
-type PollsterCreator interface {
+// FullPollster is a Pollster that knows how to get a list of Versions too
+type FullPollster interface {
 	Pollster
+	GetVersions(release, channel, arch string) (images []string, err error)
+}
+
+// PollsterWriter is a Pollster that can also create and delete images
+type PollsterWriter interface {
+	FullPollster
 	Create(filePath, release, channel, arch string, version int) (err error)
+	Delete(images ...string) (err error)
 }
 
 // Driver defines the methods required for creating images

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -30,15 +30,17 @@ import (
 	"github.com/ubuntu-core/snappy-cloud-image/pkg/image"
 )
 
+const imagesToKeep = 5
+
 // Runner is the main type of the package
 type Runner struct {
 	imgDataOrigin image.Pollster
-	imgDataTarget image.PollsterCreator
+	imgDataTarget image.PollsterWriter
 	imgDriver     image.Driver
 }
 
 // NewRunner is the Runner constructor
-func NewRunner(imgDataOrigin image.Pollster, imgDataTarget image.PollsterCreator, imgDriver image.Driver) *Runner {
+func NewRunner(imgDataOrigin image.Pollster, imgDataTarget image.PollsterWriter, imgDriver image.Driver) *Runner {
 	return &Runner{imgDataOrigin: imgDataOrigin, imgDataTarget: imgDataTarget, imgDriver: imgDriver}
 }
 
@@ -66,32 +68,38 @@ func (e *ErrActionUnknown) Error() string {
 // handles the logic of the utility
 func (r *Runner) Exec(options *flags.Options) (err error) {
 	if options.Action == "create" {
-		log.Infof("Checking current versions for release %s, channel %s and arch %s", options.Release, options.Channel, options.Arch)
-		var siVersion, cloudVersion int
-		siVersion, cloudVersion, err = r.getVersions(options.Release, options.Channel, options.Arch)
-		if err != nil {
-			return
-		}
-		if siVersion <= cloudVersion {
-			return &ErrVersion{siVersion, cloudVersion}
-		}
-		var path string
-		log.Infof("Creating image file in %s", path)
-		path, err = r.imgDriver.Create(options.Release, options.Channel, options.Arch, siVersion)
-		defer os.Remove(path)
-		if err != nil {
-			return
-		}
-		log.Infof("Uploading %s", path)
-		err = r.imgDataTarget.Create(path, options.Release, options.Channel, options.Arch, siVersion)
-		if err != nil {
-			return
-		}
-		log.Infof("Finished", path)
-	} else {
-		return &ErrActionUnknown{action: options.Action}
+		return r.create(options)
+	} else if options.Action == "cleanup" {
+		return r.cleanup(options)
 	}
+	return &ErrActionUnknown{action: options.Action}
+}
+
+func (r *Runner) create(options *flags.Options) (err error) {
+	log.Infof("Checking current versions for release %s, channel %s and arch %s", options.Release, options.Channel, options.Arch)
+	var siVersion, cloudVersion int
+	siVersion, cloudVersion, err = r.getVersions(options.Release, options.Channel, options.Arch)
+	if err != nil {
+		return
+	}
+	if siVersion <= cloudVersion {
+		return &ErrVersion{siVersion, cloudVersion}
+	}
+	var path string
+	path, err = r.imgDriver.Create(options.Release, options.Channel, options.Arch, siVersion)
+	defer os.Remove(path)
+	log.Infof("Creating image file in %s", path)
+	if err != nil {
+		return
+	}
+	log.Infof("Uploading %s", path)
+	err = r.imgDataTarget.Create(path, options.Release, options.Channel, options.Arch, siVersion)
+	if err != nil {
+		return
+	}
+	log.Infof("Finished", path)
 	return
+
 }
 
 func (r *Runner) getVersions(release, channel, arch string) (siVersion, cloudVersion int, err error) {
@@ -121,6 +129,20 @@ func (r *Runner) getVersions(release, channel, arch string) (siVersion, cloudVer
 		if _, ok := cloudError.(*cloud.ErrVersionNotFound); !ok {
 			return 0, 0, cloudError
 		}
+	}
+	return
+}
+
+func (r *Runner) cleanup(options *flags.Options) (err error) {
+	imageList, err := r.imgDataTarget.GetVersions(options.Release, options.Channel, options.Arch)
+	if err != nil {
+		return
+	}
+	if len(imageList) > imagesToKeep {
+		// assumes that imageList is sorted in descending order,
+		// the last items in the list will be the older ones
+		log.Infof("Removing images", imageList[imagesToKeep:])
+		err = r.imgDataTarget.Delete(imageList[imagesToKeep:]...)
 	}
 	return
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ubuntu-core/snappy-cloud-image/pkg/cloud"
@@ -31,22 +33,31 @@ import (
 )
 
 const (
-	siVersionError    = "error getting si version"
-	cloudVersionError = "error getting cloud version"
-	cloudCreateError  = "error creating cloud image"
-	udfCreateError    = "error creating image"
+	siVersionError          = "error getting si version"
+	cloudLatestVersionError = "error getting latest cloud version"
+	cloudVersionsError      = "error getting cloud versions"
+	cloudCreateError        = "error creating cloud image"
+	cloudDeleteError        = "error deleting cloud images"
+	udfCreateError          = "error creating image"
 )
 
-var _ = check.Suite(&runnerSuite{})
+var _ = check.Suite(&runnerCreateSuite{})
+var _ = check.Suite(&runnerCleanupSuite{})
 
 func Test(t *testing.T) { check.TestingT(t) }
 
-type runnerSuite struct {
+type runnerCreateSuite struct {
 	subject     *Runner
 	options     *flags.Options
 	siClient    *fakeSiClient
 	cloudClient *fakeCloudClient
 	udfDriver   *fakeImgDriver
+}
+
+type runnerCleanupSuite struct {
+	subject     *Runner
+	options     *flags.Options
+	cloudClient *fakeCloudClient
 }
 
 type fakeSiClient struct {
@@ -65,19 +76,23 @@ func (s *fakeSiClient) GetLatestVersion(release, channel, arch string) (ver int,
 }
 
 type fakeCloudClient struct {
-	getVersionCalls  map[string]int
-	createCalls      map[string]int
-	doVerErr         bool
-	doVerNotFoundErr bool
-	doCreateErr      bool
-	version          int
+	getLatestVersionCalls map[string]int
+	getVersionsCalls      map[string]int
+	createCalls           map[string]int
+	deleteCalls           map[string]int
+	doVerErr              bool
+	doVerNotFoundErr      bool
+	doCreateErr           bool
+	doDeleteErr           bool
+	version               int
+	versions              []string
 }
 
 func (s *fakeCloudClient) GetLatestVersion(release, channel, arch string) (ver int, err error) {
 	key := getFakeKey(release, channel, arch)
-	s.getVersionCalls[key]++
+	s.getLatestVersionCalls[key]++
 	if s.doVerErr {
-		err = fmt.Errorf(cloudVersionError)
+		err = fmt.Errorf(cloudLatestVersionError)
 	}
 	if s.doVerNotFoundErr {
 		err = cloud.NewErrVersionNotFound(release, channel, arch)
@@ -85,11 +100,29 @@ func (s *fakeCloudClient) GetLatestVersion(release, channel, arch string) (ver i
 	return s.version, err
 }
 
+func (s *fakeCloudClient) GetVersions(release, channel, arch string) (images []string, err error) {
+	key := getFakeKey(release, channel, arch)
+	s.getVersionsCalls[key]++
+	if s.doVerErr {
+		err = fmt.Errorf(cloudVersionsError)
+	}
+	return s.versions, err
+}
+
 func (s *fakeCloudClient) Create(filePath, release, channel, arch string, version int) (err error) {
 	key := getFullCreateKey(filePath, release, channel, arch, version)
 	s.createCalls[key]++
 	if s.doCreateErr {
 		err = fmt.Errorf(cloudCreateError)
+	}
+	return
+}
+
+func (s *fakeCloudClient) Delete(versions ...string) (err error) {
+	key := getDeleteKey(versions)
+	s.deleteCalls[key]++
+	if s.doDeleteErr {
+		err = fmt.Errorf(cloudDeleteError)
 	}
 	return
 }
@@ -109,7 +142,7 @@ func (s *fakeImgDriver) Create(release, channel, arch string, version int) (path
 	return s.path, err
 }
 
-func (s *runnerSuite) SetUpSuite(c *check.C) {
+func (s *runnerCreateSuite) SetUpSuite(c *check.C) {
 	s.siClient = &fakeSiClient{}
 	s.cloudClient = &fakeCloudClient{}
 	s.udfDriver = &fakeImgDriver{}
@@ -118,11 +151,11 @@ func (s *runnerSuite) SetUpSuite(c *check.C) {
 		Action: "create", Release: "15.04", Channel: "edge", Arch: "amd64"}
 }
 
-func (s *runnerSuite) SetUpTest(c *check.C) {
+func (s *runnerCreateSuite) SetUpTest(c *check.C) {
 	s.siClient.getVersionCalls = make(map[string]int)
 	s.siClient.doErr = false
 	s.siClient.version = 2
-	s.cloudClient.getVersionCalls = make(map[string]int)
+	s.cloudClient.getLatestVersionCalls = make(map[string]int)
 	s.cloudClient.createCalls = make(map[string]int)
 	s.cloudClient.doVerErr = false
 	s.cloudClient.doVerNotFoundErr = false
@@ -134,7 +167,23 @@ func (s *runnerSuite) SetUpTest(c *check.C) {
 	s.options.Action = "create"
 }
 
-func (s *runnerSuite) TestExecGetsSIVersion(c *check.C) {
+func (s *runnerCleanupSuite) SetUpSuite(c *check.C) {
+	s.cloudClient = &fakeCloudClient{}
+	s.subject = NewRunner(&fakeSiClient{}, s.cloudClient, &fakeImgDriver{})
+	s.options = &flags.Options{
+		Action: "cleanup", Release: "15.04", Channel: "edge", Arch: "amd64"}
+}
+
+func (s *runnerCleanupSuite) SetUpTest(c *check.C) {
+	s.cloudClient.getVersionsCalls = make(map[string]int)
+	s.cloudClient.deleteCalls = make(map[string]int)
+	s.cloudClient.doVerErr = false
+	s.cloudClient.doDeleteErr = false
+	s.cloudClient.versions = []string{}
+	s.options.Action = "cleanup"
+}
+
+func (s *runnerCreateSuite) TestExecCreateGetsSIVersion(c *check.C) {
 	err := s.subject.Exec(s.options)
 
 	c.Assert(err, check.IsNil)
@@ -143,7 +192,7 @@ func (s *runnerSuite) TestExecGetsSIVersion(c *check.C) {
 	c.Assert(s.siClient.getVersionCalls[key], check.Equals, 1)
 }
 
-func (s *runnerSuite) TestExecDoesNotGetSIVersionOnNonCreateAction(c *check.C) {
+func (s *runnerCreateSuite) TestExecDoesNotGetSIVersionOnNonCreateAction(c *check.C) {
 	s.options.Action = "non-create"
 	err := s.subject.Exec(s.options)
 
@@ -152,7 +201,7 @@ func (s *runnerSuite) TestExecDoesNotGetSIVersionOnNonCreateAction(c *check.C) {
 	c.Assert(len(s.siClient.getVersionCalls), check.Equals, 0)
 }
 
-func (s *runnerSuite) TestExecReturnsGetSIVersionError(c *check.C) {
+func (s *runnerCreateSuite) TestExecReturnsGetSIVersionError(c *check.C) {
 	s.siClient.doErr = true
 	err := s.subject.Exec(s.options)
 
@@ -160,40 +209,40 @@ func (s *runnerSuite) TestExecReturnsGetSIVersionError(c *check.C) {
 	c.Assert(err.Error(), check.Equals, siVersionError)
 }
 
-func (s *runnerSuite) TestExecGetsCloudVersion(c *check.C) {
+func (s *runnerCreateSuite) TestExecGetsCloudLatestVersion(c *check.C) {
 	err := s.subject.Exec(s.options)
 
 	c.Assert(err, check.IsNil)
 
 	key := getFakeKey(s.options.Release, s.options.Channel, s.options.Arch)
-	c.Assert(s.cloudClient.getVersionCalls[key], check.Equals, 1)
+	c.Assert(s.cloudClient.getLatestVersionCalls[key], check.Equals, 1)
 }
 
-func (s *runnerSuite) TestExecDoesNotGetCloudVersionOnNonCreateAction(c *check.C) {
+func (s *runnerCreateSuite) TestExecDoesNotGetCloudVersionOnNonCreateAction(c *check.C) {
 	s.options.Action = "non-create"
 	err := s.subject.Exec(s.options)
 
 	c.Assert(err, check.NotNil)
 
-	c.Assert(len(s.cloudClient.getVersionCalls), check.Equals, 0)
+	c.Assert(len(s.cloudClient.getLatestVersionCalls), check.Equals, 0)
 }
 
-func (s *runnerSuite) TestExecReturnsGetCloudVersionError(c *check.C) {
+func (s *runnerCreateSuite) TestExecReturnsGetCloudVersionError(c *check.C) {
 	s.cloudClient.doVerErr = true
 	err := s.subject.Exec(s.options)
 
 	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, cloudVersionError)
+	c.Assert(err.Error(), check.Equals, cloudLatestVersionError)
 }
 
-func (s *runnerSuite) TestExecDoesNotReturnGetCloudVersionNotFoundError(c *check.C) {
+func (s *runnerCreateSuite) TestExecDoesNotReturnGetCloudVersionNotFoundError(c *check.C) {
 	s.cloudClient.doVerNotFoundErr = true
 	err := s.subject.Exec(s.options)
 
 	c.Assert(err, check.IsNil)
 }
 
-func (s *runnerSuite) TestExecReturnsErrVersionIfCloudVersionNotLessThanSIVersion(c *check.C) {
+func (s *runnerCreateSuite) TestExecReturnsErrVersionIfCloudVersionNotLessThanSIVersion(c *check.C) {
 	testCases := []struct {
 		siVersion, cloudVersion int
 		expectedError           error
@@ -212,7 +261,7 @@ func (s *runnerSuite) TestExecReturnsErrVersionIfCloudVersionNotLessThanSIVersio
 	}
 }
 
-func (s *runnerSuite) TestExecCallsDriverCreate(c *check.C) {
+func (s *runnerCreateSuite) TestExecCallsDriverCreate(c *check.C) {
 	err := s.subject.Exec(s.options)
 
 	c.Assert(err, check.IsNil)
@@ -221,7 +270,7 @@ func (s *runnerSuite) TestExecCallsDriverCreate(c *check.C) {
 	c.Assert(s.udfDriver.createCalls[key], check.Equals, 1)
 }
 
-func (s *runnerSuite) TestExecDoesNotCallDriverCreateOnNonCreateAction(c *check.C) {
+func (s *runnerCreateSuite) TestExecDoesNotCallDriverCreateOnNonCreateAction(c *check.C) {
 	s.options.Action = "non-create"
 	err := s.subject.Exec(s.options)
 
@@ -230,7 +279,7 @@ func (s *runnerSuite) TestExecDoesNotCallDriverCreateOnNonCreateAction(c *check.
 	c.Assert(len(s.udfDriver.createCalls), check.Equals, 0)
 }
 
-func (s *runnerSuite) TestExecReturnsDriverCreateError(c *check.C) {
+func (s *runnerCreateSuite) TestExecReturnsDriverCreateError(c *check.C) {
 	s.udfDriver.doErr = true
 	err := s.subject.Exec(s.options)
 
@@ -238,7 +287,7 @@ func (s *runnerSuite) TestExecReturnsDriverCreateError(c *check.C) {
 	c.Assert(err.Error(), check.Equals, udfCreateError)
 }
 
-func (s *runnerSuite) TestExecCallsCloudCreate(c *check.C) {
+func (s *runnerCreateSuite) TestExecCallsCloudCreate(c *check.C) {
 	s.udfDriver.path = "mypath"
 	err := s.subject.Exec(s.options)
 
@@ -248,7 +297,7 @@ func (s *runnerSuite) TestExecCallsCloudCreate(c *check.C) {
 	c.Assert(s.cloudClient.createCalls[key], check.Equals, 1)
 }
 
-func (s *runnerSuite) TestExecDoesNotCallCloudCreateOnNonCreateAction(c *check.C) {
+func (s *runnerCreateSuite) TestExecDoesNotCallCloudCreateOnNonCreateAction(c *check.C) {
 	s.options.Action = "non-create"
 	err := s.subject.Exec(s.options)
 
@@ -257,7 +306,7 @@ func (s *runnerSuite) TestExecDoesNotCallCloudCreateOnNonCreateAction(c *check.C
 	c.Assert(len(s.udfDriver.createCalls), check.Equals, 0)
 }
 
-func (s *runnerSuite) TestExecReturnsCloudCreateError(c *check.C) {
+func (s *runnerCreateSuite) TestExecReturnsCloudCreateError(c *check.C) {
 	s.cloudClient.doCreateErr = true
 	err := s.subject.Exec(s.options)
 
@@ -265,7 +314,7 @@ func (s *runnerSuite) TestExecReturnsCloudCreateError(c *check.C) {
 	c.Assert(err.Error(), check.Equals, cloudCreateError)
 }
 
-func (s *runnerSuite) TestExecRemovesImageFile(c *check.C) {
+func (s *runnerCreateSuite) TestExecRemovesImageFile(c *check.C) {
 	tmpFile, err := ioutil.TempFile("", "")
 	defer os.Remove(tmpFile.Name())
 	c.Assert(err, check.IsNil)
@@ -279,13 +328,91 @@ func (s *runnerSuite) TestExecRemovesImageFile(c *check.C) {
 	c.Assert(os.IsNotExist(err), check.Equals, true)
 }
 
-func (s *runnerSuite) TestExecReturnsErrorOnInvalidAction(c *check.C) {
-	s.options.Action = "non-create"
+func (s *runnerCreateSuite) TestExecReturnsErrorOnInvalidAction(c *check.C) {
+	s.options.Action = "invalid-action"
 	err := s.subject.Exec(s.options)
 	expectedError := &ErrActionUnknown{action: s.options.Action}
 
 	c.Assert(err, check.FitsTypeOf, expectedError)
 	c.Assert(err.Error(), check.Equals, expectedError.Error())
+}
+
+func (s *runnerCleanupSuite) TestExecGetsCloudVersions(c *check.C) {
+	err := s.subject.Exec(s.options)
+
+	c.Assert(err, check.IsNil)
+
+	key := getFakeKey(s.options.Release, s.options.Channel, s.options.Arch)
+	c.Assert(s.cloudClient.getVersionsCalls[key], check.Equals, 1)
+}
+
+func (s *runnerCreateSuite) TestExecDoesNotGetCloudVersionsOnNonCleanupAction(c *check.C) {
+	s.options.Action = "non-cleanup"
+	err := s.subject.Exec(s.options)
+
+	c.Assert(err, check.NotNil)
+
+	c.Assert(len(s.cloudClient.getVersionsCalls), check.Equals, 0)
+}
+
+func (s *runnerCleanupSuite) TestExecReturnsGetVersionsError(c *check.C) {
+	s.cloudClient.doVerErr = true
+	err := s.subject.Exec(s.options)
+
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, cloudVersionsError)
+}
+
+func (s *runnerCleanupSuite) TestExecCallsDeleteForExcedentImages(c *check.C) {
+	excedent := 2
+	base := 10
+	for i := imagesToKeep + excedent; i >= 0; i-- {
+		s.cloudClient.versions = append(
+			s.cloudClient.versions,
+			cloud.GetImageID(s.options.Release, s.options.Channel, s.options.Arch, i+base))
+	}
+
+	s.subject.Exec(s.options)
+
+	expectedCall := getDeleteKey(s.cloudClient.versions[imagesToKeep:])
+
+	c.Assert(s.cloudClient.deleteCalls[expectedCall], check.Equals, 1)
+}
+
+func (s *runnerCleanupSuite) TestExecDoesNotCallDeleteWithouExcedentImages(c *check.C) {
+	base := 10
+	for i := imagesToKeep - 1; i >= 0; i-- {
+		s.cloudClient.versions = append(
+			s.cloudClient.versions,
+			cloud.GetImageID(s.options.Release, s.options.Channel, s.options.Arch, i+base))
+	}
+
+	s.subject.Exec(s.options)
+
+	c.Assert(len(s.cloudClient.deleteCalls), check.Equals, 0)
+}
+
+func (s *runnerCleanupSuite) TestExecDoesNotCallDeleteOnGetVersionsError(c *check.C) {
+	s.cloudClient.doVerErr = true
+	for i := imagesToKeep + 1; i >= 0; i-- {
+		s.cloudClient.versions = append(s.cloudClient.versions, "version"+strconv.Itoa(i))
+	}
+
+	s.subject.Exec(s.options)
+
+	c.Assert(len(s.cloudClient.deleteCalls), check.Equals, 0)
+}
+
+func (s *runnerCleanupSuite) TestExecReturnsDeleteError(c *check.C) {
+	s.cloudClient.doDeleteErr = true
+	for i := imagesToKeep + 1; i >= 0; i-- {
+		s.cloudClient.versions = append(s.cloudClient.versions, "version"+strconv.Itoa(i))
+	}
+
+	err := s.subject.Exec(s.options)
+
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, cloudDeleteError)
 }
 
 func getFakeKey(release, channel, arch string) string {
@@ -298,4 +425,8 @@ func getCreateKey(release, channel, arch string, ver int) string {
 
 func getFullCreateKey(path, release, channel, arch string, ver int) string {
 	return fmt.Sprintf("%s - %s", path, getCreateKey(release, channel, arch, ver))
+}
+
+func getDeleteKey(versions []string) string {
+	return strings.Join(versions, " ")
 }


### PR DESCRIPTION
This branch enables the `cleanup` action to keep a limited number of images for a given release, channel and arch, on execution it uses the glance client to remove the excedant images from the cloud provider. 

It determines which images to delete by sorting them in descendant version number order, the version number is included in the image name for images created with the `create` action.
