### PR TITLE
Added purge action

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -50,6 +50,7 @@ type PollsterWriter interface {
 	FullPollster
 	Create(filePath, release, channel, arch string, version int) (err error)
 	Delete(images ...string) (err error)
+	Purge() (err error)
 }
 
 // Driver defines the methods required for creating images

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -71,6 +71,8 @@ func (r *Runner) Exec(options *flags.Options) (err error) {
 		return r.create(options)
 	} else if options.Action == "cleanup" {
 		return r.cleanup(options)
+	} else if options.Action == "purge" {
+		return r.purge()
 	}
 	return &ErrActionUnknown{action: options.Action}
 }
@@ -145,4 +147,8 @@ func (r *Runner) cleanup(options *flags.Options) (err error) {
 		err = r.imgDataTarget.Delete(imageList[imagesToKeep:]...)
 	}
 	return
+}
+
+func (r *Runner) purge() (err error) {
+	return r.imgDataTarget.Purge()
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -38,11 +38,13 @@ const (
 	cloudVersionsError      = "error getting cloud versions"
 	cloudCreateError        = "error creating cloud image"
 	cloudDeleteError        = "error deleting cloud images"
+	cloudPurgeError         = "error purging cloud images"
 	udfCreateError          = "error creating image"
 )
 
 var _ = check.Suite(&runnerCreateSuite{})
 var _ = check.Suite(&runnerCleanupSuite{})
+var _ = check.Suite(&runnerPurgeSuite{})
 
 func Test(t *testing.T) { check.TestingT(t) }
 
@@ -55,6 +57,12 @@ type runnerCreateSuite struct {
 }
 
 type runnerCleanupSuite struct {
+	subject     *Runner
+	options     *flags.Options
+	cloudClient *fakeCloudClient
+}
+
+type runnerPurgeSuite struct {
 	subject     *Runner
 	options     *flags.Options
 	cloudClient *fakeCloudClient
@@ -80,10 +88,12 @@ type fakeCloudClient struct {
 	getVersionsCalls      map[string]int
 	createCalls           map[string]int
 	deleteCalls           map[string]int
+	purgeCalls            int
 	doVerErr              bool
 	doVerNotFoundErr      bool
 	doCreateErr           bool
 	doDeleteErr           bool
+	doPurgeErr            bool
 	version               int
 	versions              []string
 }
@@ -123,6 +133,14 @@ func (s *fakeCloudClient) Delete(versions ...string) (err error) {
 	s.deleteCalls[key]++
 	if s.doDeleteErr {
 		err = fmt.Errorf(cloudDeleteError)
+	}
+	return
+}
+
+func (s *fakeCloudClient) Purge() (err error) {
+	s.purgeCalls++
+	if s.doPurgeErr {
+		err = fmt.Errorf(cloudPurgeError)
 	}
 	return
 }
@@ -181,6 +199,19 @@ func (s *runnerCleanupSuite) SetUpTest(c *check.C) {
 	s.cloudClient.doDeleteErr = false
 	s.cloudClient.versions = []string{}
 	s.options.Action = "cleanup"
+}
+
+func (s *runnerPurgeSuite) SetUpSuite(c *check.C) {
+	s.cloudClient = &fakeCloudClient{}
+	s.subject = NewRunner(&fakeSiClient{}, s.cloudClient, &fakeImgDriver{})
+	s.options = &flags.Options{
+		Action: "purge", Release: "15.04", Channel: "edge", Arch: "amd64"}
+}
+
+func (s *runnerPurgeSuite) SetUpTest(c *check.C) {
+	s.cloudClient.purgeCalls = 0
+	s.cloudClient.doPurgeErr = false
+	s.options.Action = "purge"
 }
 
 func (s *runnerCreateSuite) TestExecCreateGetsSIVersion(c *check.C) {
@@ -413,6 +444,29 @@ func (s *runnerCleanupSuite) TestExecReturnsDeleteError(c *check.C) {
 
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals, cloudDeleteError)
+}
+
+func (s *runnerPurgeSuite) TestExecCallsPurge(c *check.C) {
+	s.subject.Exec(s.options)
+
+	c.Assert(s.cloudClient.purgeCalls, check.Equals, 1)
+}
+
+func (s *runnerPurgeSuite) TestExecDoesNotCallPurgeOnNonPurgeAction(c *check.C) {
+	s.options.Action = "non-purge"
+
+	s.subject.Exec(s.options)
+
+	c.Assert(s.cloudClient.purgeCalls, check.Equals, 0)
+}
+
+func (s *runnerPurgeSuite) TestExecReturnsPurgeError(c *check.C) {
+	s.cloudClient.doPurgeErr = true
+
+	err := s.subject.Exec(s.options)
+
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, cloudPurgeError)
 }
 
 func getFakeKey(release, channel, arch string) string {


### PR DESCRIPTION
This action can be used when deploying a new jenkins: because we are using instances from images created with udf called with --developer-mode, we are not using cloud-init nor the nova keypairs, the access is granted by udf copying the keys of the user creating the image to the image itself; when we create a new jenkins, new keys are created and the old images are no longer accessible.

After deploying the new jenkins and purging the old images, the image creation jobs take care of creating the new ones accessible with the new keys.
