### PR TITLE
Reduce space used in glance

### DIFF
--- a/cmd/snappy-cloud-image/main.go
+++ b/cmd/snappy-cloud-image/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	imgDataOrigin := si.NewClient(httpClient)
 	imgDataTarget := cloud.NewClient(cliExecutor)
-	imgDriver := image.NewUDF(cliExecutor)
+	imgDriver := image.NewUDFQcow2(cliExecutor)
 
 	runner := runner.NewRunner(imgDataOrigin, imgDataTarget, imgDriver)
 	if err := runner.Exec(parsedFlags); err != nil {

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -86,13 +86,14 @@ func (c *Client) Create(path, release, channel, arch string, version int) (err e
 
 	log.Debugf("Creating image %s from file %s", imageID, path)
 
-	_, err = c.cli.ExecCommand("openstack", "image", "create", "--file", path, imageID)
+	_, err = c.cli.ExecCommand("openstack", "image", "create", "--disk-format", "qcow2", "--file", path, imageID)
 	return
 }
 
 // extractVersionsFromList returns a list of image names that match the given
 // release, channel and arch sorted in descendant version number order
 func (c *Client) extractVersionsFromList(release, channel, arch string) ([]string, error) {
+	release = removeDot(release)
 	var imageIDs sort.StringSlice
 	imageIDs, err := c.getImageList(imgTemplate(release, channel, arch))
 	if err != nil {
@@ -145,6 +146,7 @@ func extractVersion(imageID string) (ver int, err error) {
 
 // GetImageID returns the image name for the given parameters
 func GetImageID(release, channel, arch string, version int) (name string) {
+	release = removeDot(release)
 	imageNamePrefix := fmt.Sprintf(imageNamePrefixPattern, release, arch, channel)
 	return fmt.Sprintf("%s-%d-%s", imageNamePrefix, version, imageNameSufix)
 }
@@ -170,4 +172,8 @@ func (c *Client) Purge() error {
 		return err
 	}
 	return c.Delete(images...)
+}
+
+func removeDot(in string) string {
+	return strings.Replace(in, ".", "", 1)
 }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -20,31 +20,46 @@
 // Package flags handles the given flags
 package flags
 
-import "flag"
+import (
+	"flag"
+	"strconv"
+)
 
 // Options has fields for the existing flags
 type Options struct {
-	Action, Release, Channel, Arch, LogLevel string
+	Action, Release, Channel, Arch, LogLevel, Qcow2compat string
 }
 
 const (
-	defaultAction   = "create"
-	defaultRelease  = "rolling"
-	defaultChannel  = "edge"
-	defaultArch     = "amd64"
-	defaultLogLevel = "info"
+	defaultAction      = "create"
+	defaultRelease     = "rolling"
+	defaultChannel     = "edge"
+	defaultArch        = "amd64"
+	defaultLogLevel    = "info"
+	defaultQcow2compat = "1.1"
 )
 
 // Parse analyzes the flags and returns a Options instance with the values
 func Parse() *Options {
 	var (
-		action   = flag.String("action", defaultAction, "action to be performed")
-		release  = flag.String("release", defaultRelease, "release of the image to be created")
-		channel  = flag.String("channel", defaultChannel, "channel of the image to be created")
-		arch     = flag.String("arch", defaultArch, "arch of the image to be created")
-		logLevel = flag.String("loglevel", defaultLogLevel, "Level of the log putput, one of debug, info, warning, error, fatal, panic")
+		action      = flag.String("action", defaultAction, "action to be performed")
+		release     = flag.String("release", defaultRelease, "release of the image to be created")
+		channel     = flag.String("channel", defaultChannel, "channel of the image to be created")
+		arch        = flag.String("arch", defaultArch, "arch of the image to be created")
+		logLevel    = flag.String("loglevel", defaultLogLevel, "Level of the log putput, one of debug, info, warning, error, fatal, panic")
+		qcow2compat = flag.String("qcow2compat", defaultQcow2compat, "Qcow2 compatibility level (0.10 or 1.1)")
 	)
 	flag.Parse()
+	dotRelease := addDot(*release)
 	return &Options{
-		Action: *action, Release: *release, Channel: *channel, Arch: *arch, LogLevel: *logLevel}
+		Action: *action, Release: dotRelease, Channel: *channel, Arch: *arch, LogLevel: *logLevel, Qcow2compat: *qcow2compat}
+}
+
+func addDot(release string) string {
+	if len(release) == 4 {
+		if _, err := strconv.Atoi(release); err == nil {
+			return release[0:2] + "." + release[2:]
+		}
+	}
+	return release
 }

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -79,6 +79,12 @@ func (s *flagsSuite) TestParseDefaultLoglevel(c *check.C) {
 	c.Assert(parsedFlags.LogLevel, check.Equals, defaultLogLevel)
 }
 
+func (s *flagsSuite) TestParseDefaultQcow2compat(c *check.C) {
+	parsedFlags := Parse()
+
+	c.Assert(parsedFlags.Qcow2compat, check.Equals, defaultQcow2compat)
+}
+
 func (s *flagsSuite) TestParseSetsActionToFlagValue(c *check.C) {
 	os.Args = []string{"", "-action", "myaction"}
 	parsedFlags := Parse()
@@ -91,6 +97,24 @@ func (s *flagsSuite) TestParseSetsReleaseToFlagValue(c *check.C) {
 	parsedFlags := Parse()
 
 	c.Assert(parsedFlags.Release, check.Equals, "myrelease")
+}
+
+func (s *flagsSuite) TestParseSetsReleaseToFlagValueAddingDots(c *check.C) {
+	os.Args = []string{"", "-release", "1504"}
+	parsedFlags := Parse()
+	c.Assert(parsedFlags.Release, check.Equals, "15.04")
+}
+
+func (s *flagsSuite) TestParseSetsReleaseToFlagValueAddingDotsWithLeadingZeros(c *check.C) {
+	os.Args = []string{"", "-release", "0023"}
+	parsedFlags := Parse()
+	c.Assert(parsedFlags.Release, check.Equals, "00.23")
+}
+
+func (s *flagsSuite) TestParseSetsReleaseToFlagValueNotAddingDotsForLongNumbers(c *check.C) {
+	os.Args = []string{"", "-release", "12345"}
+	parsedFlags := Parse()
+	c.Assert(parsedFlags.Release, check.Equals, "12345")
 }
 
 func (s *flagsSuite) TestParseSetsChannelToFlagValue(c *check.C) {
@@ -112,6 +136,13 @@ func (s *flagsSuite) TestParseSetsLogLevelToFlagValue(c *check.C) {
 	parsedFlags := Parse()
 
 	c.Assert(parsedFlags.LogLevel, check.Equals, "myloglevel")
+}
+
+func (s *flagsSuite) TestParseSetsQcow2compatToFlagValue(c *check.C) {
+	os.Args = []string{"", "-qcow2compat", "myqcow2compat"}
+	parsedFlags := Parse()
+
+	c.Assert(parsedFlags.Qcow2compat, check.Equals, "myqcow2compat")
 }
 
 // from flag.ResetForTesting

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -151,8 +151,8 @@ type fakeImgDriver struct {
 	doErr       bool
 }
 
-func (s *fakeImgDriver) Create(release, channel, arch string, version int) (path string, err error) {
-	key := getCreateKey(release, channel, arch, version)
+func (s *fakeImgDriver) Create(options *flags.Options, version int) (path string, err error) {
+	key := getCreateKey(options.Release, options.Channel, options.Arch, version)
 	s.createCalls[key]++
 	if s.doErr {
 		err = fmt.Errorf(udfCreateError)
@@ -241,15 +241,6 @@ func (s *runnerCreateSuite) TestExecReturnsGetSIVersionError(c *check.C) {
 	c.Assert(err.Error(), check.Equals, siVersionError)
 }
 
-func (s *runnerCreateSuite) TestExecGetSIVersionReceivesReleaseWithDot(c *check.C) {
-	s.options.Release = "1504"
-
-	s.subject.Exec(s.options)
-
-	key := getFakeKey("15.04", s.options.Channel, s.options.Arch)
-	c.Assert(s.siClient.getVersionCalls[key], check.Equals, 1)
-}
-
 func (s *runnerCreateSuite) TestExecGetsCloudLatestVersion(c *check.C) {
 	s.options.Release = "1504"
 	err := s.subject.Exec(s.options)
@@ -257,14 +248,6 @@ func (s *runnerCreateSuite) TestExecGetsCloudLatestVersion(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	key := getFakeKey(s.options.Release, s.options.Channel, s.options.Arch)
-	c.Assert(s.cloudClient.getLatestVersionCalls[key], check.Equals, 1)
-}
-
-func (s *runnerCreateSuite) TestExecGetCloudLatestVersionReceivesReleaseWithoutDot(c *check.C) {
-	s.options.Release = "15.04"
-	s.subject.Exec(s.options)
-
-	key := getFakeKey("1504", s.options.Channel, s.options.Arch)
 	c.Assert(s.cloudClient.getLatestVersionCalls[key], check.Equals, 1)
 }
 
@@ -327,15 +310,6 @@ func (s *runnerCreateSuite) TestExecDoesNotCallDriverCreateOnNonCreateAction(c *
 	c.Assert(err, check.NotNil)
 
 	c.Assert(len(s.udfDriver.createCalls), check.Equals, 0)
-}
-
-func (s *runnerCreateSuite) TestExecDriverCreateReceivesReleaseWithDot(c *check.C) {
-	s.options.Release = "1504"
-
-	s.subject.Exec(s.options)
-
-	key := getCreateKey("15.04", s.options.Channel, s.options.Arch, s.siClient.version)
-	c.Assert(s.udfDriver.createCalls[key], check.Equals, 1)
 }
 
 func (s *runnerCreateSuite) TestExecReturnsDriverCreateError(c *check.C) {


### PR DESCRIPTION
Images uploaded to glance in qcow2 format; only keep 3 images for each triplet
