### PR TITLE
Added imageType param

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -27,7 +27,7 @@ import (
 
 // Options has fields for the existing flags
 type Options struct {
-	Action, Release, Channel, Arch, LogLevel, Qcow2compat, OS, Kernel, Gadget string
+	Action, Release, Channel, Arch, LogLevel, Qcow2compat, OS, Kernel, Gadget, ImageType string
 }
 
 const (
@@ -40,6 +40,7 @@ const (
 	defaultKernel      = "canonical-pc-linux.canonical"
 	defaultOS          = "ubuntu-core.canonical"
 	defaultGadget      = "canonical-pc.canonical"
+	defaultImageType   = "custom"
 )
 
 // Parse analyzes the flags and returns a Options instance with the values
@@ -57,6 +58,8 @@ func Parse() *Options {
 			"Kernel snap of the image to be built, defaults to "+defaultKernel)
 		gadget = flag.String("gadget", defaultGadget,
 			"Gadget snap of the image to be built, defaults to "+defaultGadget)
+		imageType = flag.String("image-type", defaultImageType,
+			"Type of image to be built, this string will be put in the image name. Defaults to "+defaultImageType)
 	)
 	flag.Parse()
 	dotRelease := addDot(*release)
@@ -69,7 +72,8 @@ func Parse() *Options {
 		Qcow2compat: *qcow2compat,
 		OS:          *os,
 		Kernel:      *kernel,
-		Gadget:      *gadget}
+		Gadget:      *gadget,
+		ImageType:   *imageType}
 }
 
 func addDot(release string) string {

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -103,6 +103,12 @@ func (s *flagsSuite) TestParseDefaultGadget(c *check.C) {
 	c.Assert(parsedFlags.Gadget, check.Equals, defaultGadget)
 }
 
+func (s *flagsSuite) TestParseDefaultImageType(c *check.C) {
+	parsedFlags := Parse()
+
+	c.Assert(parsedFlags.ImageType, check.Equals, defaultImageType)
+}
+
 func (s *flagsSuite) TestParseSetsActionToFlagValue(c *check.C) {
 	os.Args = []string{"", "-action", "myaction"}
 	parsedFlags := Parse()
@@ -182,6 +188,13 @@ func (s *flagsSuite) TestParseSetsGadgetToFlagValue(c *check.C) {
 	parsedFlags := Parse()
 
 	c.Assert(parsedFlags.Gadget, check.Equals, "mygadget")
+}
+
+func (s *flagsSuite) TestParseSetsImageTypeToFlagValue(c *check.C) {
+	os.Args = []string{"", "-image-type", "myimagetype"}
+	parsedFlags := Parse()
+
+	c.Assert(parsedFlags.ImageType, check.Equals, "myimagetype")
 }
 
 // from flag.ResetForTesting

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -40,21 +40,21 @@ const (
 
 // Pollster holds the methods for querying an image backend
 type Pollster interface {
-	GetLatestVersion(release, channel, arch string) (ver int, err error)
+	GetLatestVersion(options *flags.Options) (ver int, err error)
 }
 
 // FullPollster is a Pollster that knows how to get a list of Versions too
 type FullPollster interface {
 	Pollster
-	GetVersions(release, channel, arch string) (images []string, err error)
+	GetVersions(options *flags.Options) (images []string, err error)
 }
 
 // PollsterWriter is a Pollster that can also create and delete images
 type PollsterWriter interface {
 	FullPollster
-	Create(filePath, release, channel, arch string, version int) (err error)
+	Create(filePath string, options *flags.Options, version int) (err error)
 	Delete(images ...string) (err error)
-	Purge() (err error)
+	Purge(options *flags.Options) (err error)
 }
 
 // Driver defines the methods required for creating images

--- a/pkg/si/si.go
+++ b/pkg/si/si.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2015 Canonical Ltd
+ * Copyright (C) 2015, 2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/ubuntu-core/snappy-cloud-image/pkg/flags"
 	"github.com/ubuntu-core/snappy-cloud-image/pkg/web"
 )
 
@@ -69,8 +70,8 @@ type file struct {
 
 // GetLatestVersion returns the highest version from the system image server for the given
 // release, channel and arch, or an error in case something goes wrong
-func (c *Client) GetLatestVersion(release, channel, arch string) (ver int, err error) {
-	url := generateURL(release, channel, arch)
+func (c *Client) GetLatestVersion(options *flags.Options) (ver int, err error) {
+	url := generateURL(options)
 	content, err := c.httpClient.Get(url)
 	if err != nil {
 		return
@@ -94,10 +95,10 @@ func (c *Client) GetLatestVersion(release, channel, arch string) (ver int, err e
 	return
 }
 
-func generateURL(release, channel, arch string) string {
-	if arch == "arm" {
-		arch += "hf"
+func generateURL(options *flags.Options) string {
+	if options.Arch == "arm" {
+		options.Arch += "hf"
 	}
 	return fmt.Sprintf("%s/%s/%s/generic_%s/%s",
-		baseURL, release, channel, arch, dataFileName)
+		baseURL, options.Release, options.Channel, options.Arch, dataFileName)
 }


### PR DESCRIPTION
The image type is included in the image name, so that we can create new images without affecting the existing ones. The pattern is now `ubuntu-core/{{ imageType }}/ubuntu-...`

This will be useful when we automate the validation of new images, we can continue executing tests on old images while the new one is being validated, once it's ok to go we replace the old with the new one. 

Also unified the image interfaces to accept a flag.Options argument.
