### PR TITLE
updated build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,13 +7,13 @@ Build-Depends: bzr,
                dh-golang,
                git,
                golang-check.v1-dev,
-               golang-github-ubuntu-core-snappy-dev,
+               golang-github-snapcore-snapd-dev,
                golang-go,
                golang-logrus-dev,
                golang-pb-dev,
                golang-yaml.v2-dev,
                mercurial,
-Standards-Version: 3.9.6
+Standards-Version: 3.9.8
 Homepage: https://github.com/ubuntu-core/snappy-cloud-image
 Vcs-Browser: https://github.com/ubuntu-core/snappy-cloud-image
 


### PR DESCRIPTION
We were getting a build error [1], this should fix it

[1] https://launchpadlibrarian.net/263318800/buildlog_ubuntu-xenial-amd64.snappy-cloud-image_1.0.0ubuntu2-1~47~ubuntu16.04.1_BUILDING.txt.gz
